### PR TITLE
Tweak collection name in metadata

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -32,7 +32,7 @@
 		<meta property="authority" refines="#subject-1">LCSH</meta>
 		<meta property="term" refines="#subject-1">sh85037269</meta>
 		<meta property="se:subject">Mystery</meta>
-		<meta id="collection-1" property="belongs-to-collection">Haycraft Queen Cornerstones</meta>
+		<meta id="collection-1" property="belongs-to-collection">Haycraft-Queen Cornerstones</meta>
 		<meta property="collection-type" refines="#collection-1">set</meta>
 		<dc:description id="description">A seemingly impossible murder commited during the trade union movement becomes the obsession of London’s Bow district.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">


### PR DESCRIPTION
This still had the old collection name without the hyphen. Updated to match changes to other books such as https://github.com/standardebooks/sax-rohmer_the-insidious-dr-fu-manchu/commit/898732fb04deae8fb9470e61d32be4be8f1f1aca